### PR TITLE
improvement: [mysql] aggregate btree index in alter table sql

### DIFF
--- a/dt-common/src/meta/struct_meta/statement/mysql_create_table_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/mysql_create_table_statement.rs
@@ -7,6 +7,7 @@ use crate::meta::struct_meta::structure::{
     structure_type::StructureType,
     table::Table,
 };
+use crate::meta::struct_meta::structure::index::IndexType;
 
 #[derive(Debug, Clone)]
 pub struct MysqlCreateTableStatement {
@@ -42,25 +43,51 @@ impl MysqlCreateTableStatement {
             sqls.push((key, Self::table_to_sql(&mut self.table)));
         }
 
-        for i in self.indexes.iter_mut() {
-            match i.index_kind {
-                IndexKind::Unique => {
-                    if filter.filter_structure(&StructureType::Table) {
-                        continue;
+        if self.indexes.len() > 0 {
+            let mut idx_appends = Vec::new();
+            for i in self.indexes.iter_mut() {
+                match i.index_kind {
+                    IndexKind::Unique => {
+                        if filter.filter_structure(&StructureType::Table) {
+                            continue;
+                        }
+                    },
+                    _ => {
+                        if filter.filter_structure(&StructureType::Index) {
+                            continue;
+                        }
                     }
                 }
-                _ => {
-                    if filter.filter_structure(&StructureType::Index) {
-                        continue;
+
+                match i.index_type {
+                    // join Btree index for same table
+                    IndexType::Btree => {
+                        idx_appends.push(Self::index_to_sql_appends(i));
+                    },
+                    _ => {
+                        let standalone_key = format!(
+                            "index.{}.{}.{}",
+                            i.database_name, i.table_name, i.index_name
+                        );
+                        sqls.push((standalone_key, Self::index_to_sql(i)))
                     }
                 }
             }
-
-            let key = format!(
-                "index.{}.{}.{}",
-                i.database_name, i.table_name, i.index_name
-            );
-            sqls.push((key, Self::index_to_sql(i)));
+            if idx_appends.len() > 0 {
+                let key = format!(
+                    "index.{}.{}",
+                    self.indexes[0].database_name, self.indexes[0].table_name
+                );
+                sqls.push((
+                    key,
+                    format!(
+                        "ALTER TABLE `{}`.`{}` {}",
+                        self.table.database_name,
+                        self.table.table_name,
+                        idx_appends.join(",")
+                    ),
+                ))
+            }
         }
 
         if !filter.filter_structure(&StructureType::Constraint) {
@@ -170,21 +197,12 @@ impl MysqlCreateTableStatement {
     }
 
     fn index_to_sql(index: &mut Index) -> String {
-        index
-            .columns
-            .sort_by(|a, b| a.seq_in_index.cmp(&b.seq_in_index));
-        let columns_sql = index
-            .columns
-            .iter()
-            .filter(|x| !x.column_name.is_empty())
-            .map(|x| format!("`{}`", x.column_name))
-            .collect::<Vec<String>>()
-            .join(",");
+        let columns_sql = Self::build_cols_for_index(index);
 
-        let mut sql = format!(
-            // no need index_type in "CREATE {} INDEX `{}` USING {IndexType}"
-            // since only BETREE supported in both InnoDB and MyISAM
-            // refer: https://dev.mysql.com/doc/refman/8.0/en/create-index.html
+        // no need index_type in "CREATE {} INDEX `{}` USING {IndexType}"
+        // since only BETREE supported in both InnoDB and MyISAM
+        // refer: https://dev.mysql.com/doc/refman/8.0/en/create-index.html
+        let mut sql: String = format!(
             "CREATE {} INDEX `{}` ON `{}`.`{}` ({}) ",
             index.index_kind, index.index_name, index.database_name, index.table_name, columns_sql
         );
@@ -194,6 +212,37 @@ impl MysqlCreateTableStatement {
         }
 
         sql
+    }
+
+    fn index_to_sql_appends(index: &mut Index) -> String {
+        let columns_sql = Self::build_cols_for_index(index);
+
+        // no need index_type in "CREATE {} INDEX `{}` USING {IndexType}"
+        // since only BETREE supported in both InnoDB and MyISAM
+        // refer: https://dev.mysql.com/doc/refman/8.0/en/create-index.html
+        let mut sql: String = format!(
+            "ADD {} INDEX `{}` ({}) ",
+            index.index_kind, index.index_name, columns_sql
+        );
+
+        if !index.comment.is_empty() {
+            sql.push_str(&format!("COMMENT '{}' ", index.comment));
+        }
+
+        sql
+    }
+
+    fn build_cols_for_index(index: &mut Index) -> String {
+        index
+            .columns
+            .sort_by(|a, b| a.seq_in_index.cmp(&b.seq_in_index));
+        index
+            .columns
+            .iter()
+            .filter(|x| !x.column_name.is_empty())
+            .map(|x| format!("`{}`", x.column_name))
+            .collect::<Vec<String>>()
+            .join(",")
     }
 
     fn constraint_to_sql(constraint: &Constraint) -> String {

--- a/dt-tests/tests/mysql_to_mysql/struct/basic_test/expect_ddl_5.7.sql
+++ b/dt-tests/tests/mysql_to_mysql/struct/basic_test/expect_ddl_5.7.sql
@@ -51,12 +51,19 @@ CREATE TABLE `full_index_type` (
   `f_7` text,
   `f_8` text,
   `f_9` point NOT NULL,
+  `f_10` varchar(10) DEFAULT NULL,
+  `f_11` varchar(10) DEFAULT NULL,
+  `f_12` varchar(10) DEFAULT NULL,
+  `f_13` varchar(10) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_unique_1` (`f_1`,`f_2`,`f_3`),
   UNIQUE KEY `idx_unique_2` (`f_3`),
   SPATIAL KEY `idx_spatial_1` (`f_9`),
   FULLTEXT KEY `idx_full_text_1` (`f_6`,`f_7`,`f_8`),
-  FULLTEXT KEY `idx_full_text_2` (`f_8`)
+  FULLTEXT KEY `idx_full_text_2` (`f_8`),
+  KEY `idx_btree_text_1` (`f_10`),
+  KEY `idx_btree_text_2` (`f_11`),
+  KEY `idx_btree_text_3` (`f_13`,`f_12`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8
 
 struct_it_mysql2mysql_1.constraint_table

--- a/dt-tests/tests/mysql_to_mysql/struct/basic_test/expect_ddl_8.0.sql
+++ b/dt-tests/tests/mysql_to_mysql/struct/basic_test/expect_ddl_8.0.sql
@@ -51,12 +51,19 @@ CREATE TABLE `full_index_type` (
   `f_7` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci,
   `f_8` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci,
   `f_9` point NOT NULL,
+  `f_10` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
+  `f_11` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
+  `f_12` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
+  `f_13` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_unique_1` (`f_1`,`f_2`,`f_3`),
   UNIQUE KEY `idx_unique_2` (`f_3`),
   SPATIAL KEY `idx_spatial_1` (`f_9`),
   FULLTEXT KEY `idx_full_text_1` (`f_6`,`f_7`,`f_8`),
-  FULLTEXT KEY `idx_full_text_2` (`f_8`)
+  FULLTEXT KEY `idx_full_text_2` (`f_8`),
+  KEY `idx_btree_text_1` (`f_10`),
+  KEY `idx_btree_text_2` (`f_11`),
+  KEY `idx_btree_text_3` (`f_13`,`f_12`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3
 
 struct_it_mysql2mysql_1.constraint_table

--- a/dt-tests/tests/mysql_to_mysql/struct/basic_test/src_prepare.sql
+++ b/dt-tests/tests/mysql_to_mysql/struct/basic_test/src_prepare.sql
@@ -52,7 +52,12 @@ CREATE TABLE struct_it_mysql2mysql_1.full_index_type(
     f_6 TEXT,
     f_7 TEXT, 
     f_8 TEXT, 
-    f_9 POINT NOT NULL
+    f_9 POINT NOT NULL,
+    f_10 varchar(10),
+    f_11 varchar(10),
+    f_12 varchar(10),
+    f_13 varchar(10),
+    KEY idx_btree_text_1 (f_10)
 );
 ```
 
@@ -74,6 +79,10 @@ CREATE FULLTEXT INDEX idx_full_text_2 ON struct_it_mysql2mysql_1.full_index_type
 -- spatial index
 -- only 1 column supported in spatial key
 CREATE SPATIAL INDEX idx_spatial_1 ON struct_it_mysql2mysql_1.full_index_type(f_9);
+
+CREATE INDEX idx_btree_text_2 ON struct_it_mysql2mysql_1.full_index_type(f_11);
+
+CREATE INDEX idx_btree_text_3 ON struct_it_mysql2mysql_1.full_index_type(f_13, f_12);
 
 -- full constraint
 ```


### PR DESCRIPTION
aggregate btree indexes in alter table sql to increase index creation speed for MySQL